### PR TITLE
Update Gnome SDK to 3.36

### DIFF
--- a/net.oz9aec.Gpredict.json
+++ b/net.oz9aec.Gpredict.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "net.oz9aec.Gpredict",
 	"runtime": "org.gnome.Platform",
-	"runtime-version": "3.34",
+	"runtime-version": "3.36",
 	"sdk": "org.gnome.Sdk",
 	"command": "gpredict",
 	"copy-icon": true,


### PR DESCRIPTION
Gnome SDK 3.34 is EOL. Update the SDK to 3.36.