### PR TITLE
Fix the display version in About

### DIFF
--- a/net.oz9aec.Gpredict.yml
+++ b/net.oz9aec.Gpredict.yml
@@ -34,9 +34,13 @@ modules:
   - shared-modules/intltool/intltool-0.51.json
   - name: gpredict
     sources:
+      - type: patch
+        path: no-configure.patch
+        use-git: true
       - type: git
         url: https://github.com/csete/gpredict
         commit: aa5771036f078e8f5bafa958661ac98ad3ed8f32
+        disable-shallow-clone: true
       - type: file
         path: net.oz9aec.Gpredict.appdata.xml
     post-install:

--- a/no-configure.patch
+++ b/no-configure.patch
@@ -1,0 +1,14 @@
+diff --git a/autogen.sh b/autogen.sh
+index ff4da99..001d1e3 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -51,8 +51,7 @@ echo "- autoconf."		&& \
+   autoconf			&& \
+ echo "- automake."		&& \
+   automake --add-missing --gnu	&& \
+-echo				&& \
+-  ./configure "$@"		&& exit 0
++exit 0
+ 
+ exit 1
+ 


### PR DESCRIPTION
The version in the About dialog shows UNKNOWN.

- Remove the call to configure from autogen.sh
- Make the git clone no shallow to get the version info properly