### PR TITLE
Update version in AppStream metadata

### DIFF
--- a/net.oz9aec.Gpredict.appdata.xml
+++ b/net.oz9aec.Gpredict.appdata.xml
@@ -25,6 +25,7 @@
 </screenshot>
 </screenshots>
 <releases>
+    <release version="2.3.115" date="2022-08-07"/>
     <release version="2.3.105" date="2021-05-08"/>
     <release version="2.3.103" date="2021-04-14"/>
     <release version="2.2.1" date="2018-01-21"/>


### PR DESCRIPTION
I forgot to bump the Gpredict version in my previous PR. This PR fixes it.

/cc @hfiguiere